### PR TITLE
fix: escape revision range

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,18 @@ const tagRegex = /tag:\s*([^,)]+)/g;
 const commitDetailsRegex = /^(.+);(.+);(.+)$/;
 
 /**
- * Run shell command and resolve with stdout content
+ * Spawn a child process and resolve with stdout content
  *
- * @param  {string} command Shell command
+ * @param  {string}        command Command to spawn
+ * @param  {Array<string>} args    Command arguments
  * @return {Promise<string,Error>}
  */
-function runCommand(command) {
-  return childProcess.exec(command)
-    .then(result => result.stdout);
+function runCommand(command, args) {
+  const ps = childProcess.spawn(command, args, {
+    capture: ['stdout', 'stderr'],
+  });
+
+  return ps.then(result => result.stdout);
 }
 
 /**
@@ -126,10 +130,10 @@ function compareCommit(a, b) {
 function getList(options) {
   const range = isString(options) ? options : (options && options.range);
   const rev = options && options.rev;
-  const fmt = '--pretty="%d;%H;%ci" --decorate=short';
-  const cmd = rev ? `git log --simplify-by-decoration ${fmt} ${rev}` : `git log --no-walk --tags ${fmt}`;
+  const log = ['log', '--pretty="%d;%H;%ci"', '--decorate=short'];
+  const args = rev ? log.concat('--simplify-by-decoration', rev.split(/ +/)) : log.concat('--no-walk', '--tags');
 
-  return runCommand(cmd).then((output) => {
+  return runCommand('git', args).then((output) => {
     const lines = output.split('\n');
     const tags = flatten(lines.map(parseLine));
 


### PR DESCRIPTION
The shell command to query the tags accepts user input since version "1.3.0" but It doesn't escaped it; e.g. `getList({rev: ‘HEAD; rm -rf /’})` would query the tags from the current branch and then try to remove everything.

Tagged Version now spawns a git child process instead of executing a shell command, and let child-process-promise escape all arguments.