### PR TITLE
[WIP] Swith from git process to nodegit

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -10,5 +10,15 @@ module.exports = {
         tabWidth: 2,
       },
     ],
+    'comma-dangle': [
+      'error',
+      {
+        arrays: 'always-multiline',
+        objects: 'always-multiline',
+        imports: 'always-multiline',
+        exports: 'always-multiline',
+        functions: 'never',
+      },
+    ],
   },
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+
 language: node_js
 
 node_js:
@@ -12,3 +14,18 @@ script:
 
 after_success:
   - "./node_modules/.bin/nyc report --reporter=text-lcov | ./node_modules/.bin/coveralls"
+
+env:
+  - CXX=g++-4.9
+
+addons:
+
+  apt:
+
+    sources:
+      - ubuntu-toolchain-r-test
+      - git-core
+
+    packages:
+      - g++-4.9
+      - git

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
   - "7"
 
 before_script:
-  - "npm install nodegit@0.17"
+  - "npm install nodegit@0.18"
   - "npm install"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ dist: trusty
 language: node_js
 
 node_js:
-  - "5"
   - "6"
+  - "7"
 
 before_script:
   - "npm install"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ node_js:
   - "7"
 
 before_script:
+  - "npm install nodegit@0.17"
   - "npm install"
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - "6"
   - "7"
 
-before_script:
+install:
   - "npm install nodegit@0.18"
   - "npm install"
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Installation
 ```sh
-npm install nodegit@0.17 --save
+npm install nodegit@0.18 --save
 npm install tagged-versions --save
 ```
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Installation
 ```sh
+npm install nodegit@0.17 --save
 npm install tagged-versions --save
 ```
 

--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "bluebird": "^3.4.7",
     "git-range": "^0.1.4",
     "lodash.omit": "^4.5.0",
-    "nodegit": "^0.17.0",
     "semver": "^5.3.0"
+  },
+  "peerDependencies": {
+    "nodegit": "^0.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -49,11 +49,11 @@
   },
   "dependencies": {
     "bluebird": "^3.4.7",
-    "git-range": "^0.1.4",
+    "git-range": "^0.2.0",
     "lodash.omit": "^4.5.0",
     "semver": "^5.3.0"
   },
   "peerDependencies": {
-    "nodegit": "^0.17.0"
+    "nodegit": "^0.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "eslint-plugin-import": "^2.2.0",
     "nyc": "^10.1.2",
     "rb-conventional-changelog": "^1.1.9",
-    "sinon": "^1.17.6"
+    "shelljs": "^0.7.6",
+    "sinon": "^1.17.6",
+    "tempfile": "^1.1.1"
   },
   "dependencies": {
     "child-process-promise": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "ava": "^0.18.1",
+    "child-process-promise": "^2.1.3",
     "coveralls": "^2.11.16",
     "eslint": "^3.15.0",
     "eslint-config-airbnb-base": "^11.1.0",
@@ -47,7 +48,10 @@
     "tempfile": "^1.1.1"
   },
   "dependencies": {
-    "child-process-promise": "^2.1.3",
+    "bluebird": "^3.4.7",
+    "git-range": "^0.1.4",
+    "lodash.omit": "^4.5.0",
+    "nodegit": "^0.17.0",
     "semver": "^5.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "validate": "./node_modules/eslint/bin/eslint.js src",
+    "validate": "./node_modules/eslint/bin/eslint.js src test",
     "test": "./node_modules/.bin/nyc ./node_modules/.bin/ava --verbose",
     "watch": "ava --watch",
     "coverage": "nyc ava"

--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
     }
   },
   "devDependencies": {
-    "ava": "^0.16.0",
-    "coveralls": "^2.11.14",
-    "eslint": "^3.5.0",
-    "eslint-config-airbnb-base": "^7.1.0",
-    "eslint-plugin-import": "^1.15.0",
-    "nyc": "^8.3.0",
+    "ava": "^0.18.1",
+    "coveralls": "^2.11.16",
+    "eslint": "^3.15.0",
+    "eslint-config-airbnb-base": "^11.1.0",
+    "eslint-plugin-import": "^2.2.0",
+    "nyc": "^10.1.2",
     "rb-conventional-changelog": "^1.1.9",
     "sinon": "^1.17.6"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -16,10 +16,12 @@ function isString(v) {
 /**
  * Get list of tag with a  semantic version name.
  *
- * @param  {object|string}   optionsOrRange     Options map or range string
- * @param  {string}          options.range      Semantic range to filter tags with
- * @param  {string|string[]} options.rev        Revision range to filter tags with
- * @return {Promise<Array<Commit>,Error>}
+ * @param  {object|string}      [optionsOrRange] Options map or range string
+ * @param  {nodegit.Repository} [options.repo]   nodegit repository
+ * @param  {string}             [options.gitDir] Path to the repository
+ * @param  {string}             [options.range]  Semantic range to filter tags with
+ * @param  {string|string[]}    [options.rev]    Revision range to filter tags with
+ * @return {Promise<Commit[],Error>}
  */
 function getList(optionsOrRange) {
   const options = isString(optionsOrRange) ? { range: optionsOrRange } : optionsOrRange;
@@ -31,9 +33,11 @@ function getList(optionsOrRange) {
 /**
  * Get most recent tag.
  *
- * @param  {object|string}   optionsOrRange     Options map or range string
- * @param  {string}          options.range      Semantic range to filter tag with
- * @param  {string|string[]} options.rev        Revision range to filter tag with
+ * @param  {object|string}      [optionsOrRange] Options map or range string
+ * @param  {nodegit.Repository} [options.repo]   nodegit repository
+ * @param  {string}             [options.gitDir] Path to the repository
+ * @param  {string}             [options.range]  Semantic range to filter tag with
+ * @param  {string|string[]}    [options.rev]    Revision range to filter tag with
  * @return {Promise<Commit,Error>}
  */
 function getLastVersion(optionsOrRange) {

--- a/src/index.js
+++ b/src/index.js
@@ -6,167 +6,38 @@
 
 'use strict';
 
-const semver = require('semver');
-const childProcess = require('child-process-promise');
-
-const tagRegex = /tag:\s*([^,)]+)/g;
-const commitDetailsRegex = /^(.+);(.+);(.+)$/;
-
-/**
- * Spawn a child process and resolve with stdout content
- *
- * @param  {string}        command Command to spawn
- * @param  {Array<string>} args    Command arguments
- * @return {Promise<string,Error>}
- */
-function runCommand(command, args) {
-  const ps = childProcess.spawn(command, args, {
-    capture: ['stdout', 'stderr'],
-  });
-
-  return ps.then(result => result.stdout);
-}
-
-/**
- * Run git command.
- *
- * @param  {Array<string>} cmd            Git command to run
- * @param  {object}        options        Options
- * @param  {string}        options.gitDir Path to the git directory (let git find the repo by default)
- * @return {Promise<string,Error>}
- */
-function git(cmd, options) {
-  const gitDir = options && options.gitDir;
-  const args = gitDir == null ? cmd : ['--git-dir', gitDir].concat(cmd);
-
-  return runCommand('git', args);
-}
-
-/**
- * Get all tags with a semantic version name out of a list of Refs
- *
- * @param  {string} refs List of refs
- * @return {Arrays<Commit>}
- */
-function getSemanticCommits(refs) {
-  const tagNames = [];
-  let match = [];
-
-  // Finding successive matches
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/exec#Finding_successive_matches
-  while (match) {
-    match = tagRegex.exec(refs);
-
-    if (match) {
-      tagNames.push(match[1]);
-    }
-  }
-
-  return tagNames.map(name => ({
-    tag: name,
-    version: semver.valid(name),
-    hash: null,
-    date: null,
-  })).filter(
-    tag => tag.version != null
-  );
-}
+const getRepo = require('./repo');
+const getTags = require('./tags');
 
 function isString(v) {
   return typeof v === 'string';
 }
 
 /**
- * Parse commit into an array of tag object.
- *
- * @param  {string} line Line to parse
- * @return {Array<Commit>}
- */
-function parseLine(line) {
-  const match = commitDetailsRegex.exec(line);
-
-  if (!match || match.length < 4) {
-    return [];
-  }
-
-  const tags = getSemanticCommits(match[1]);
-  const hash = match[2].trim();
-  const date = new Date(match[3].trim());
-
-  return tags.map(tag => Object.assign(tag, { hash, date }));
-}
-
-/**
- * Merge the arrays of elements into one array.
- *
- * @param  {Array<Array<any>>} arrays The list of array to merge
- * @return {Array<any>}
- */
-function flatten(tags) {
-  return Array.prototype.concat.apply([], tags);
-}
-
-/**
- * Filter tags with range.
- *
- * Skip filtering if the range is not set.
- *
- * @param  {Array<Commit>} tags  List of tags
- * @param  {string}     range Semantic range to filter with.
- * @return {Array<Commit>}
- */
-function filterByRange(tags, range) {
-  if (!range) {
-    return tags;
-  }
-
-  return tags.filter(tag => semver.satisfies(tag.version, range));
-}
-
-/**
- * Compare tag by version.
- *
- * @param  {Commit} a First tag
- * @param  {Commit} b Second tag
- * @return {number}
- */
-function compareCommit(a, b) {
-  return semver.rcompare(a.version, b.version);
-}
-
-/**
  * Get list of tag with a  semantic version name.
  *
- * @param  {object|string} options       Options map or range string
- * @param  {string}        options.range Semantic range to filter tag with
- * @param  {string}        options.rev   Revision range to filter tag with
+ * @param  {object|string}   optionsOrRange     Options map or range string
+ * @param  {string}          options.range      Semantic range to filter tags with
+ * @param  {string|string[]} options.rev        Revision range to filter tags with
  * @return {Promise<Array<Commit>,Error>}
  */
-function getList(options) {
-  const range = isString(options) ? options : (options && options.range);
-  const rev = options && options.rev;
-  const log = ['log', '--pretty="%d;%H;%ci"', '--decorate=short'];
-  const args = rev ? log.concat('--simplify-by-decoration', rev.split(/ +/)) : log.concat('--no-walk', '--tags');
+function getList(optionsOrRange) {
+  const options = isString(optionsOrRange) ? { range: optionsOrRange } : optionsOrRange;
 
-  return git(args, options).then((output) => {
-    const lines = output.split('\n');
-    const tags = flatten(lines.map(parseLine));
-
-    return filterByRange(tags, range).sort(compareCommit);
-  });
+  return getRepo(options)
+    .then(repo => getTags(repo, options));
 }
 
 /**
  * Get most recent tag.
  *
- * @param  {object|string} options       Options map or range string
- * @param  {string}        options.range Semantic range to filter tag with
- * @param  {string}        options.rev   Revision range to filter tag with
+ * @param  {object|string}   optionsOrRange     Options map or range string
+ * @param  {string}          options.range      Semantic range to filter tag with
+ * @param  {string|string[]} options.rev        Revision range to filter tag with
  * @return {Promise<Commit,Error>}
  */
-function getLastVersion(options) {
-  return getList(options)
-    .then(list => list[0]);
+function getLastVersion(optionsOrRange) {
+  return getList(optionsOrRange).then(commits => commits[0]);
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -13,14 +13,18 @@ const tagRegex = /tag:\s*([^,)]+)/g;
 const commitDetailsRegex = /^(.+);(.+);(.+)$/;
 
 /**
- * Run shell command and resolve with stdout content
+ * Spawn a child process and resolve with stdout content
  *
- * @param  {string} command Shell command
+ * @param  {string}        command Command to spawn
+ * @param  {Array<string>} args    Command arguments
  * @return {Promise<string,Error>}
  */
-function runCommand(command) {
-  return childProcess.exec(command)
-    .then(result => result.stdout);
+function runCommand(command, args) {
+  const ps = childProcess.spawn(command, args, {
+    capture: ['stdout', 'stderr'],
+  });
+
+  return ps.then(result => result.stdout);
 }
 
 /**
@@ -126,10 +130,10 @@ function compareCommit(a, b) {
 function getList(options) {
   const range = isString(options) ? options : (options && options.range);
   const rev = options && options.rev;
-  const fmt = '--pretty="%d;%H;%ci" --decorate=short';
-  const cmd = rev ? `git log --simplify-by-decoration ${fmt} ${rev}` : `git log --no-walk --tags ${fmt}`;
+  const log = ['log', '--pretty="%d;%H;%ci"', '--decorate=short'];
+  const args = rev ? log.concat('--simplify-by-decoration', rev.split(/ +/)) : log.concat('--no-walk', '--tags');
 
-  return runCommand(cmd).then((output) => {
+  return runCommand('git', args).then((output) => {
     const lines = output.split('\n');
     const tags = flatten(lines.map(parseLine));
 

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,21 @@ function runCommand(command, args) {
 }
 
 /**
+ * Run git command.
+ *
+ * @param  {Array<string>} cmd            Git command to run
+ * @param  {object}        options        Options
+ * @param  {string}        options.gitDir Path to the git directory (let git find the repo by default)
+ * @return {Promise<string,Error>}
+ */
+function git(cmd, options) {
+  const gitDir = options && options.gitDir;
+  const args = gitDir == null ? cmd : ['--git-dir', gitDir].concat(cmd);
+
+  return runCommand('git', args);
+}
+
+/**
  * Get all tags with a semantic version name out of a list of Refs
  *
  * @param  {string} refs List of refs
@@ -133,7 +148,7 @@ function getList(options) {
   const log = ['log', '--pretty="%d;%H;%ci"', '--decorate=short'];
   const args = rev ? log.concat('--simplify-by-decoration', rev.split(/ +/)) : log.concat('--no-walk', '--tags');
 
-  return runCommand('git', args).then((output) => {
+  return git(args, options).then((output) => {
     const lines = output.split('\n');
     const tags = flatten(lines.map(parseLine));
 

--- a/src/repo.js
+++ b/src/repo.js
@@ -16,10 +16,15 @@ function find(gitDir) {
  * Target the repository at the provided path or try to find the the repository
  * in the current working directory or its parents.
  *
- * @param  {object} [options.gitDir] Path to the repository.
+ * @param  {object}             [options.gitDir] Path to the repository
+ * @param  {nodegit.Repository} [options.repo]   nodegit repository
  * @return {Promise<nodegit.Repository, Error>}
  */
-module.exports = function openRepo({ gitDir } = {}) {
+module.exports = function openRepo({ gitDir, repo } = {}) {
+  if (repo != null) {
+    return Promise.resolve(repo);
+  }
+
   return find(gitDir)
     .then(dir => git.Repository.open(dir));
 };

--- a/src/repo.js
+++ b/src/repo.js
@@ -16,7 +16,7 @@ function find(gitDir) {
  * Target the repository at the provided path or try to find the the repository
  * in the current working directory or its parents.
  *
- * @param  {object}             [options.gitDir] Path to the repository
+ * @param  {string}             [options.gitDir] Path to the repository
  * @param  {nodegit.Repository} [options.repo]   nodegit repository
  * @return {Promise<nodegit.Repository, Error>}
  */

--- a/src/repo.js
+++ b/src/repo.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const git = require('nodegit');
+
+function find(gitDir) {
+  if (gitDir) {
+    return Promise.resolve(gitDir);
+  }
+
+  return git.Repository.discover('.', 0, '');
+}
+
+/**
+ * Initial a nodegit repository.
+ *
+ * Target the repository at the provided path or try to find the the repository
+ * in the current working directory or its parents.
+ *
+ * @param  {object} [options.gitDir] Path to the repository.
+ * @return {Promise<nodegit.Repository, Error>}
+ */
+module.exports = function openRepo({ gitDir } = {}) {
+  return find(gitDir)
+    .then(dir => git.Repository.open(dir));
+};

--- a/src/tags.js
+++ b/src/tags.js
@@ -93,9 +93,9 @@ function processResult(repo, tags) {
 /**
  * Retrieve the list of tag with semver name.
  *
- * @param  {nodegit.Repository} repo          Repository to list the tag of
- * @param  {string}             options.range Semantic range to filter tag with
- * @param  {string}             options.rev   Rev range the tags should be part of
+ * @param  {nodegit.Repository} repo            Repository to list the tag of
+ * @param  {string}             [options.range] Semantic range to filter tag with
+ * @param  {string}             [options.rev]   Rev range the tags should be part of
  * @return {Promise<{hash: string, tag: string, version: string, date: Date},Error>
  */
 module.exports = function getTags(repo, { range, rev } = {}) {

--- a/src/tags.js
+++ b/src/tags.js
@@ -1,0 +1,112 @@
+'use strict';
+
+const git = require('nodegit');
+const gitRange = require('git-range');
+const omit = require('lodash.omit');
+const Promise = require('bluebird');
+const semver = require('semver');
+
+function satisfies(range) {
+  return tagName => semver.valid(tagName) && semver.satisfies(tagName, range);
+}
+
+function filterTagNames(names, range) {
+  const test = range == null ? semver.valid : satisfies(range);
+
+  return names.filter(test);
+}
+
+function lookupHash(repo, name) {
+  return git.AnnotatedCommit.fromRevspec(repo, name)
+    .then(tag => ({
+      oid: tag.id(),
+      hash: tag.id().toString(),
+      tag: name,
+      version: semver.valid(name),
+    }));
+}
+
+function semverTags(repo, range) {
+  return git.Tag.list(repo)
+    .then((names) => {
+      const semverNames = filterTagNames(names, range);
+
+      return Promise.all(semverNames.map(lookupHash.bind(null, repo)));
+    });
+}
+
+function filterTags(repo, tags, range) {
+  const walker = range.walker();
+  const tagsMap = tags.reduce(
+    (map, tag) => {
+      const list = map.get(tag.hash);
+
+      if (!list) {
+        map.set(tag.hash, [tag]);
+      } else {
+        list.push(tag);
+      }
+
+      return map;
+    },
+    new Map([])
+  );
+  const result = [];
+  const iterCommits = () => walker.next()
+    .then((oid) => {
+      const list = tagsMap.get(oid.toString());
+
+      if (list) {
+        result.push(...list);
+      }
+
+      return iterCommits();
+    })
+    .catch((err) => {
+      /* istanbul ignore next */
+      if (err.errno !== git.Error.CODE.ITEROVER) {
+        return Promise.reject(err);
+      }
+
+      return result;
+    });
+
+  return iterCommits();
+}
+
+function lookupDate(repo, tag) {
+  return repo.getCommit(tag.oid)
+    .then(commit => Object.assign(tag, { date: commit.date() }));
+}
+
+function compareTags(a, b) {
+  return semver.rcompare(a.version, b.version);
+}
+
+function processResult(repo, tags) {
+  const addDate = lookupDate.bind(null, repo);
+
+  return Promise.all(tags.map(addDate))
+    .then(commits => commits.map(c => omit(c, 'oid')).sort(compareTags));
+}
+
+/**
+ * Retrieve the list of tag with semver name.
+ *
+ * @param  {nodegit.Repository} repo          Repository to list the tag of
+ * @param  {string}             options.range Semantic range to filter tag with
+ * @param  {string}             options.rev   Rev range the tags should be part of
+ * @return {Promise<{hash: string, tag: string, version: string, date: Date},Error>
+ */
+module.exports = function getTags(repo, { range, rev } = {}) {
+  const tagsPromise = semverTags(repo, range);
+  const finish = processResult.bind(null, repo);
+
+  if (rev == null) {
+    return tagsPromise.then(finish);
+  }
+
+  return Promise.all([tagsPromise, gitRange.parse(repo, rev)])
+    .spread(filterTags.bind(null, repo))
+    .then(finish);
+};

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,10 @@
+module.exports = {
+  extends: require.resolve('../.eslintrc.js'),
+  rules: {
+    'import/no-extraneous-dependencies': [
+      'error', {
+        devDependencies: true
+      }
+    ]
+  },
+};

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,5 +1,13 @@
 module.exports = {
   extends: require.resolve('../.eslintrc.js'),
+  parserOptions: {
+    ecmaFeatures: {
+      jsx: false,
+      experimentalObjectRestSpread: false,
+    },
+    ecmaVersion: '2017',
+    sourceType: 'module',
+  },
   rules: {
     'import/no-extraneous-dependencies': [
       'error', {

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -1,0 +1,59 @@
+import path from 'path';
+
+import shell from 'shelljs';
+import tempfile from 'tempfile';
+import childProcess from 'child-process-promise';
+
+export default function tempRepo() {
+  const repo = tempfile();
+  const gitDir = path.join(repo, '.git');
+
+  return {
+
+    get root() {
+      return repo;
+    },
+
+    get gitDir() {
+      return gitDir;
+    },
+
+    async run(...cmd) {
+      const ps = childProcess.spawn('git', ['--git-dir', gitDir, ...cmd], {
+        capture: ['stdout', 'stderr'],
+      });
+
+      return ps.then(result => result.stdout.trim())
+        .catch(err => Promise.reject(new Error(`Failed to run "git ${cmd.join(' ')}": ${err.stderr}`)));
+    },
+
+    async init(name = 'Alice Smith', email = 'alice@example.com') {
+      shell.mkdir('-p', repo);
+      await this.run('init', repo);
+      await this.run('config', 'user.name', name);
+      await this.run('config', 'user.email', email);
+    },
+
+    async commit(subject, lines = [], author = 'Bob Smith <bob@example.com>') {
+      const msg = [subject].concat('', lines).join('\n').trim();
+
+      await this.run('commit', '--allow-empty', `--author=${author}`, `--message=${msg}`);
+    },
+
+    async info({ grep }) {
+      const line = await this.run('log', '--grep', grep, '--format=%H%x00%ci%x00%s', '-1');
+      const [hash, isoDate] = line.split('\0');
+
+      if (!hash) {
+        throw new Error(`Cannot find commit with message "${grep}"`);
+      }
+
+      return { hash, date: new Date(isoDate) };
+    },
+
+    remove() {
+      shell.rm('-rf', repo);
+    },
+
+  };
+}

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,131 +1,109 @@
-'use strict';
+import test from 'ava';
 
-const test = require('ava');
-const sinon = require('sinon');
-const childProcess = require('child-process-promise');
-const taggedVersions = require('../src');
+import semver from 'semver';
+import taggedVersions from '../';
+import tempRepo from './helpers/index';
 
-const gitLog = `
-(HEAD -> master, tag: v1.2.0, origin/master, origin/HEAD);f6bf448b02c489c8676f2eeaaac72ef93980baf2;2016-10-08 11:47:01 +0100
-(tag: v1.1.1);cd88316d6976ce8878a90a1a6d4eb326d16a4d68;2016-10-01 17:34:24 +0100
-(tag: v1.1.0, tag: stable);61fca7630fbe863f8d890d7a33e9b45f786d79e8;2016-09-27 22:35:42 +0100
-(tag: v1.0.0);9c5d6e1930831431c005bc74543f61a5cb36d617;2016-09-26 23:56:00 +0100
-(tag: init);9c5d6e1930831431c005bc74543f61a5cb36d618;2016-09-26 23:56:00 +0100
-`;
+const repo = tempRepo();
 
-const versions = {
-  '1.2.0': {
-    version: '1.2.0',
-    tag: 'v1.2.0',
-    hash: 'f6bf448b02c489c8676f2eeaaac72ef93980baf2',
-    date: new Date('2016-10-08T11:47:01+01:00'),
-  },
-  '1.1.1': {
-    version: '1.1.1',
+test.before(async () => {
+  await repo.init();
+  await repo.commit('chore: chore1');
+  await repo.run('tag', '-m', 'named', 'init');
+  await repo.commit('chore: chore2');
+  await repo.run('tag', '-m', '1.0.0', 'v1.0.0');
+  await repo.commit('feat: feat1');
+  await repo.commit('feat: feat2');
+  await repo.run('tag', '-m', '1.1.0-0', 'v1.1.0-0');
+  await repo.commit('fix: fix1');
+  await repo.commit('fix: fix2');
+  await repo.run('tag', 'v1.1.0-1'); // lightweight tag
+  await repo.run('tag', '-m', '1.1.0', 'v1.1.0'); // annotated tag
+  await repo.run('tag', '-m', 'named', 'stable');
+  await repo.commit('fix: fix3');
+  await repo.commit('fix: fix4');
+  await repo.run('tag', '-m', '1.1.1', 'v1.1.1');
+  await repo.commit('fix: fix5');
+});
+
+test.beforeEach((t) => {
+  // eslint-disable-next-line no-param-reassign
+  t.context.pwd = process.cwd();
+});
+
+test.afterEach.always((t) => {
+  process.chdir(t.context.pwd);
+});
+
+test.after.always(async () => {
+  await repo.remove();
+});
+
+async function getTags() {
+  return Promise.all([{
     tag: 'v1.1.1',
-    hash: 'cd88316d6976ce8878a90a1a6d4eb326d16a4d68',
-    date: new Date('2016-10-01T17:34:24+01:00'),
-  },
-  '1.1.0': {
-    version: '1.1.0',
+    commit: 'fix: fix4',
+  }, {
     tag: 'v1.1.0',
-    hash: '61fca7630fbe863f8d890d7a33e9b45f786d79e8',
-    date: new Date('2016-09-27T22:35:42+01:00'),
-  },
-  '1.0.0': {
-    version: '1.0.0',
+    commit: 'fix: fix2',
+  }, {
+    tag: 'v1.1.0-1',
+    commit: 'fix: fix2',
+  }, {
+    tag: 'v1.1.0-0',
+    commit: 'feat: feat2',
+  }, {
     tag: 'v1.0.0',
-    hash: '9c5d6e1930831431c005bc74543f61a5cb36d617',
-    date: new Date('2016-09-26T23:56:00+01:00'),
-  },
-};
+    commit: 'chore: chore2',
+  }].map(async ({ tag, commit }) => {
+    const { hash, date } = await repo.info({ grep: commit });
 
-test.beforeEach(() => {
-  sinon.stub(childProcess, 'spawn').returns(Promise.resolve({ stdout: gitLog }));
+    return { hash, date, tag, version: semver.valid(tag) };
+  }));
+}
+
+test.serial('return all tagged versions', async (t) => {
+  process.chdir(repo.root);
+
+  const tags = await taggedVersions.getList();
+  const expected = await getTags();
+
+  t.deepEqual(tags, expected);
 });
 
-test.afterEach.always(() => childProcess.spawn.restore());
+test.serial('return all tagged versions within a range', async (t) => {
+  process.chdir(repo.root);
 
-test.serial('query tagged versions from a specific git repository', t => taggedVersions
-    .getList({ gitDir: '.git' })
-    .then(() => {
-      t.true(childProcess.spawn.calledOnce);
-      t.deepEqual(childProcess.spawn.lastCall.args, [
-        'git', ['--git-dir', '.git', 'log', '--pretty="%d;%H;%ci"', '--decorate=short', '--no-walk', '--tags'], {
-          capture: ['stdout', 'stderr'],
-        },
-      ]);
-    }));
+  const tags = await taggedVersions.getList('^1.1.0');
+  const expected = await getTags();
 
-test.serial('return all tagged versions', t => taggedVersions.getList()
-    .then((list) => {
-      t.deepEqual(list, [versions['1.2.0'], versions['1.1.1'], versions['1.1.0'], versions['1.0.0']]);
-      t.true(childProcess.spawn.calledOnce);
-      t.deepEqual(childProcess.spawn.lastCall.args, [
-        'git', ['log', '--pretty="%d;%H;%ci"', '--decorate=short', '--no-walk', '--tags'], {
-          capture: ['stdout', 'stderr'],
-        },
-      ]);
-    }));
-
-test.serial('return all tagged versions within a range', t => taggedVersions.getList('^1.1.0')
-    .then((list) => {
-      t.deepEqual(list, [versions['1.2.0'], versions['1.1.1'], versions['1.1.0']]);
-      t.true(childProcess.spawn.calledOnce);
-      t.deepEqual(childProcess.spawn.lastCall.args, [
-        'git', ['log', '--pretty="%d;%H;%ci"', '--decorate=short', '--no-walk', '--tags'], {
-          capture: ['stdout', 'stderr'],
-        },
-      ]);
-    }));
-
-test.serial('Query tags in a revision range', async (t) => {
-  await taggedVersions.getList({ rev: 'v1.0.0..v1.1.0' });
-
-  t.true(childProcess.spawn.calledOnce);
-  t.deepEqual(childProcess.spawn.lastCall.args, [
-    'git', ['log', '--pretty="%d;%H;%ci"', '--decorate=short', '--simplify-by-decoration', 'v1.0.0..v1.1.0'], {
-      capture: ['stdout', 'stderr'],
-    },
-  ]);
-
-  await taggedVersions.getList({ rev: '^v1.0.0 v1.1.0' });
-
-  t.true(childProcess.spawn.calledTwice);
-  t.deepEqual(childProcess.spawn.lastCall.args, [
-    'git', ['log', '--pretty="%d;%H;%ci"', '--decorate=short', '--simplify-by-decoration', '^v1.0.0', 'v1.1.0'], {
-      capture: ['stdout', 'stderr'],
-    },
-  ]);
+  t.deepEqual(tags, expected.slice(0, 2));
 });
 
-test.serial('return all tagged versions from the branch', (t) => {
-  const stdout = ` (HEAD -> feat-simplify-by-decoration, tag: v1.2.0, origin/master, origin/HEAD, master);f6bf448b02c489c8676f2eeaaac72ef93980baf2;2016-10-08 11:47:01 +0100
- (tag: v1.1.1);cd88316d6976ce8878a90a1a6d4eb326d16a4d68;2016-10-01 17:34:24 +0100
- (tag: v1.1.0);61fca7630fbe863f8d890d7a33e9b45f786d79e8;2016-09-27 22:35:42 +0100
- (tag: v1.0.0);9c5d6e1930831431c005bc74543f61a5cb36d617;2016-09-26 23:56:00 +0100
-;af5c58c9cde876f66719e2c10a80a51cde52865b;2016-09-26 12:17:44 +0100`;
+test('Query tags in a dotted revision range', async (t) => {
+  const tags = await taggedVersions.getList({ gitDir: repo.gitDir, rev: 'v1.0.0..v1.1.0' });
+  const expected = await getTags();
 
-  childProcess.spawn.returns(Promise.resolve({ stdout }));
-
-  return taggedVersions.getList({ rev: 'HEAD' })
-    .then((list) => {
-      t.deepEqual(list, [versions['1.2.0'], versions['1.1.1'], versions['1.1.0'], versions['1.0.0']]);
-      t.true(childProcess.spawn.calledOnce);
-      t.deepEqual(childProcess.spawn.lastCall.args, [
-        'git', ['log', '--pretty="%d;%H;%ci"', '--decorate=short', '--simplify-by-decoration', 'HEAD'], {
-          capture: ['stdout', 'stderr'],
-        },
-      ]);
-    });
+  t.deepEqual(tags, expected.slice(1, -1));
 });
 
-test.serial('return last tagged version', t => taggedVersions.getLastVersion()
-    .then((version) => {
-      t.deepEqual(version, versions['1.2.0']);
-    }));
+test('Query tags in a revision range', async (t) => {
+  const tags = await taggedVersions.getList({ gitDir: repo.gitDir, rev: '^v1.0.0 v1.1.0' });
+  const expected = await getTags();
 
-test.serial('return last tagged version within a range', t => taggedVersions.getLastVersion('~1.1')
-    .then((version) => {
-      t.deepEqual(version, versions['1.1.1']);
-    }));
+  t.deepEqual(tags, expected.slice(1, -1));
+});
+
+test('return last tagged version', async (t) => {
+  const tags = await taggedVersions.getLastVersion({ gitDir: repo.gitDir });
+  const expected = await getTags();
+
+  t.deepEqual(tags, expected[0]);
+});
+
+test('return last tagged version within a range', async (t) => {
+  const tags = await taggedVersions.getLastVersion({ gitDir: repo.gitDir, range: '~1.0' });
+  const expected = await getTags();
+
+  t.deepEqual(tags, expected.pop());
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -80,30 +80,30 @@ test.serial('return all tagged versions within a range', async (t) => {
   t.deepEqual(tags, expected.slice(0, 2));
 });
 
-test('Query tags in a dotted revision range', async (t) => {
-  const tags = await taggedVersions.getList({ gitDir: repo.gitDir, rev: 'v1.0.0..v1.1.0' });
+test('Query tags in between two revision', async (t) => {
+  const tags = await taggedVersions.getList({ gitDir: repo.gitDir, rev: 'v1.1.0..HEAD' });
   const expected = await getTags();
 
-  t.deepEqual(tags, expected.slice(1, -1));
-});
-
-test('Query tags in a revision range', async (t) => {
-  const tags = await taggedVersions.getList({ gitDir: repo.gitDir, rev: '^v1.0.0 v1.1.0' });
-  const expected = await getTags();
-
-  t.deepEqual(tags, expected.slice(1, -1));
+  t.deepEqual(tags, expected.slice(0, 1));
 });
 
 test('return last tagged version', async (t) => {
-  const tags = await taggedVersions.getLastVersion({ gitDir: repo.gitDir });
+  const tag = await taggedVersions.getLastVersion({ gitDir: repo.gitDir });
   const expected = await getTags();
 
-  t.deepEqual(tags, expected[0]);
+  t.deepEqual(tag, expected[0]);
 });
 
-test('return last tagged version within a range', async (t) => {
-  const tags = await taggedVersions.getLastVersion({ gitDir: repo.gitDir, range: '~1.0' });
-  const expected = await getTags();
+test.serial('return last tagged version within a range', async (t) => {
+  process.chdir(repo.root);
 
-  t.deepEqual(tags, expected.pop());
+  const tag = await taggedVersions.getLastVersion('~1.0');
+
+  t.deepEqual(tag.version, '1.0.0');
+});
+
+test('Query last tagged version within a revision range', async (t) => {
+  const tag = await taggedVersions.getLastVersion({ gitDir: repo.gitDir, rev: 'v1.1.0^@' });
+
+  t.deepEqual(tag.version, '1.1.0-0');
 });

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,14 +40,11 @@ const versions = {
   },
 };
 
-test.beforeEach((t) => {
-  t.context.exec = childProcess.exec;
-  childProcess.exec = sinon.stub().returns(Promise.resolve({ stdout: gitLog }));
+test.beforeEach(() => {
+  sinon.stub(childProcess, 'exec').returns(Promise.resolve({ stdout: gitLog }));
 });
 
-test.afterEach((t) => {
-  childProcess.exec = t.context.exec;
-});
+test.afterEach.always(() => childProcess.exec.restore());
 
 test.serial('return all tagged versions', t => taggedVersions.getList()
     .then((list) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -40,36 +40,32 @@ const versions = {
   },
 };
 
-test.beforeEach(t => {
+test.beforeEach((t) => {
   t.context.exec = childProcess.exec;
   childProcess.exec = sinon.stub().returns(Promise.resolve({ stdout: gitLog }));
 });
 
-test.afterEach(t => {
+test.afterEach((t) => {
   childProcess.exec = t.context.exec;
 });
 
-test.serial('return all tagged versions', (t) => {
-  return taggedVersions.getList()
+test.serial('return all tagged versions', t => taggedVersions.getList()
     .then((list) => {
       t.deepEqual(list, [versions['1.2.0'], versions['1.1.1'], versions['1.1.0'], versions['1.0.0']]);
       t.true(childProcess.exec.calledOnce);
       t.deepEqual(childProcess.exec.lastCall.args, [
         'git log --no-walk --tags --pretty="%d;%H;%ci" --decorate=short',
       ]);
-    });
-});
+    }));
 
-test.serial('return all tagged versions within a range', (t) => {
-  return taggedVersions.getList('^1.1.0')
+test.serial('return all tagged versions within a range', t => taggedVersions.getList('^1.1.0')
     .then((list) => {
       t.deepEqual(list, [versions['1.2.0'], versions['1.1.1'], versions['1.1.0']]);
       t.true(childProcess.exec.calledOnce);
       t.deepEqual(childProcess.exec.lastCall.args, [
         'git log --no-walk --tags --pretty="%d;%H;%ci" --decorate=short',
       ]);
-    });
-});
+    }));
 
 test.serial('return all tagged versions from the branch', (t) => {
   const stdout = ` (HEAD -> feat-simplify-by-decoration, tag: v1.2.0, origin/master, origin/HEAD, master);f6bf448b02c489c8676f2eeaaac72ef93980baf2;2016-10-08 11:47:01 +0100
@@ -90,16 +86,12 @@ test.serial('return all tagged versions from the branch', (t) => {
     });
 });
 
-test.serial('return last tagged version', (t) => {
-  return taggedVersions.getLastVersion()
+test.serial('return last tagged version', t => taggedVersions.getLastVersion()
     .then((version) => {
       t.deepEqual(version, versions['1.2.0']);
-    });
-});
+    }));
 
-test.serial('return last tagged version within a range', (t) => {
-  return taggedVersions.getLastVersion('~1.1')
+test.serial('return last tagged version within a range', t => taggedVersions.getLastVersion('~1.1')
     .then((version) => {
       t.deepEqual(version, versions['1.1.1']);
-    });
-});
+    }));

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -49,6 +49,18 @@ test.afterEach(t => {
   childProcess.spawn = t.context.spawn;
 });
 
+test.serial('query tagged versions from a specific git repository', (t) => {
+  return taggedVersions.getList({ gitDir: '.git' })
+    .then(() => {
+      t.true(childProcess.spawn.calledOnce);
+      t.deepEqual(childProcess.spawn.lastCall.args, [
+        'git', ['--git-dir', '.git', 'log', '--pretty="%d;%H;%ci"', '--decorate=short', '--no-walk', '--tags'], {
+          capture: ['stdout', 'stderr'],
+        },
+      ]);
+    });
+});
+
 test.serial('return all tagged versions', (t) => {
   return taggedVersions.getList()
     .then((list) => {

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -1,0 +1,43 @@
+import test from 'ava';
+import shell from 'shelljs';
+
+import getRepo from '../src/repo';
+import tempRepo from './helpers/index';
+
+const tmp = tempRepo();
+
+test.before(async () => {
+  await tmp.init();
+  await tmp.commit('chore: chore1');
+});
+
+test.beforeEach((t) => {
+  // eslint-disable-next-line no-param-reassign
+  t.context.pwd = process.cwd();
+});
+
+test.afterEach.always((t) => {
+  process.chdir(t.context.pwd);
+});
+
+test.after.always(async () => {
+  await tmp.remove();
+});
+
+test('should open the repository', async (t) => {
+  const repo = await getRepo(tmp);
+  const commit = await repo.getHeadCommit();
+
+  t.deepEqual(commit.message().trim(), 'chore: chore1');
+});
+
+test.serial('should find the repository', async (t) => {
+  shell.cd(tmp.root);
+  shell.mkdir('-p', 'foo/bar');
+  shell.cd('foo/bar');
+
+  const repo = await getRepo();
+  const commit = await repo.getHeadCommit();
+
+  t.deepEqual(commit.message().trim(), 'chore: chore1');
+});

--- a/test/repo.spec.js
+++ b/test/repo.spec.js
@@ -1,4 +1,5 @@
 import test from 'ava';
+import git from 'nodegit';
 import shell from 'shelljs';
 
 import getRepo from '../src/repo';
@@ -29,6 +30,13 @@ test('should open the repository', async (t) => {
   const commit = await repo.getHeadCommit();
 
   t.deepEqual(commit.message().trim(), 'chore: chore1');
+});
+
+test.serial('should use the provided nodegit.Repository', async (t) => {
+  const expected = await git.Repository.open(tmp.gitDir);
+  const actual = await getRepo({ repo: expected });
+
+  t.is(actual, expected);
 });
 
 test.serial('should find the repository', async (t) => {

--- a/test/tags.spec.js
+++ b/test/tags.spec.js
@@ -1,0 +1,126 @@
+import test from 'ava';
+
+import getRepo from '../src/repo';
+import getTags from '../src/tags';
+import tempRepo from './helpers/index';
+
+const tmp = tempRepo();
+
+test.before(async () => {
+  await tmp.init();
+  await tmp.commit('chore: chore1');
+  await tmp.run('tag', '-m', 'named', 'init');
+  await tmp.commit('chore: chore2');
+  await tmp.run('tag', '-m', '1.0.0', 'v1.0.0');
+  await tmp.commit('feat: feat1');
+  await tmp.commit('feat: feat2');
+  await tmp.run('tag', '-m', '1.1.0-0', 'v1.1.0-0');
+  await tmp.commit('fix: fix1');
+  await tmp.commit('fix: fix2');
+  await tmp.run('tag', 'v1.1.0-1'); // lightweight tag
+  await tmp.run('tag', '-m', '1.1.0', 'v1.1.0'); // annotated tag
+  await tmp.run('tag', '-m', 'named', 'stable');
+  await tmp.commit('fix: fix3');
+  await tmp.commit('fix: fix4');
+  await tmp.run('tag', '-m', '1.1.1', 'v1.1.1');
+  await tmp.commit('fix: fix5');
+  await tmp.run('checkout', '-b', 'next', 'v1.1.0');
+  await tmp.commit('feat: feat3');
+  await tmp.run('tag', '-m', '2.0.0-0', 'v2.0.0-0');
+  await tmp.run('checkout', 'master');
+});
+
+test.after.always(async () => {
+  await tmp.remove();
+});
+
+
+test('should list all tags', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo);
+
+  t.deepEqual(tags.map(tag => tag.tag), [
+    'v2.0.0-0',
+    'v1.1.1',
+    'v1.1.0',
+    'v1.1.0-1',
+    'v1.1.0-0',
+    'v1.0.0',
+  ]);
+});
+
+test('should include version (no prefix)', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo);
+
+  t.deepEqual(tags.map(tag => tag.version), [
+    '2.0.0-0',
+    '1.1.1',
+    '1.1.0',
+    '1.1.0-1',
+    '1.1.0-0',
+    '1.0.0',
+  ]);
+});
+
+test('should include commit hash', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo);
+  const expected = await Promise.all([
+    'feat: feat3',
+    'fix: fix4',
+    'fix: fix2',
+    'fix: fix2',
+    'feat: feat2',
+    'chore: chore2',
+  ].map(msg => tmp.info({ grep: msg }).then(info => info.hash)));
+
+  t.deepEqual(tags.map(tag => tag.hash), expected);
+});
+
+test('should filter tags by range', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo, { range: 'x.x.x' });
+
+  t.deepEqual(tags.map(tag => tag.tag), [
+    'v1.1.1',
+    'v1.1.0',
+    'v1.0.0',
+  ]);
+});
+
+test('should filter by branch', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo, { rev: 'master' });
+
+  t.deepEqual(tags.map(tag => tag.tag), [
+    'v1.1.1',
+    'v1.1.0',
+    'v1.1.0-1',
+    'v1.1.0-0',
+    'v1.0.0',
+  ]);
+});
+
+test('should filter by previous tag', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo, { rev: 'v1.1.0-0' });
+
+  t.deepEqual(tags.map(tag => tag.tag), [
+    'v1.1.0-0',
+    'v1.0.0',
+  ]);
+});
+
+test('should filter by initial tag', async (t) => {
+  const repo = await getRepo(tmp);
+  const tags = await getTags(repo, { rev: ['next', 'master', '^v1.1.0-0~1'] });
+
+  t.deepEqual(tags.map(tag => tag.tag), [
+    'v2.0.0-0',
+    'v1.1.1',
+    'v1.1.0',
+    'v1.1.0-1',
+    'v1.1.0-0',
+  ]);
+});


### PR DESCRIPTION
Tagged-version might dependent of the git version and and of shell environment. By using nodegit, the targeting platform only need to be able to compile nodegit.

Having the right git version and correctly installed might be easier than for npm to compiling nodegit, so I am not sure how to implement it; maybe as an extra module, like `require('tagged-versions/nodegit')` or a different package `require('tagged-versions-nodegit')`. 

Also, I am not sure how to require `nodegit`; I think it should be a peer dependencies but thta's two package to install instead of one.